### PR TITLE
Correção de erros nas funções initialize_var(), equal() e smaller()

### DIFF
--- a/src/expLogic.c
+++ b/src/expLogic.c
@@ -18,15 +18,50 @@
 void equal(STACK *s)
 {
     DADOS x = pop(s);
-    long *a = x.dados;
-
     DADOS y = pop(s);
-    long *b = y.dados;
 
-    if (*b == *a)
-        push_long(s, 1);
-    else
-        push_long(s, 0);
+    if (x.tipo == LONG && y.tipo == LONG)
+    {
+        long *a = x.dados;
+        long *b = y.dados;
+
+        if (*b == *a)
+            push_long(s, 1);
+        else
+            push_long(s, 0);
+    }
+    else if (x.tipo == LONG && y.tipo == DOUBLE)
+    {
+        long *ai = x.dados;
+        double a = *ai;
+        double *b = y.dados;
+        
+        if (*b == a)
+            push_long(s, 1);
+        else
+            push_long(s, 0);        
+    }
+    else if (x.tipo == DOUBLE && y.tipo == LONG)
+    {
+        double *a = x.dados;
+        long *bi = y.dados;
+        double b = *bi;
+        
+        if (b == *a)
+            push_long(s, 1);
+        else
+            push_long(s, 0);
+    }
+    else if (x.tipo == DOUBLE && y.tipo == DOUBLE)
+    {
+        double *a = x.dados;
+        double *b = y.dados;
+        
+        if (*b == *a)
+            push_long(s, 1);
+        else
+            push_long(s, 0);
+    }
 
     free(x.dados);
     free(y.dados);
@@ -40,15 +75,50 @@ void equal(STACK *s)
 void smaller(STACK *s)
 {
     DADOS x = pop(s);
-    long *a = x.dados;
-    
     DADOS y = pop(s);
-    long *b = y.dados;
 
-    if (*b < *a)
-        push_long(s, 1);
-    else
-        push_long(s, 0);
+    if (x.tipo == LONG && y.tipo == LONG)
+    {
+        long *a = x.dados;
+        long *b = y.dados;
+
+        if (*b < *a)
+            push_long(s, 1);
+        else
+            push_long(s, 0);
+    }
+    else if (x.tipo == LONG && y.tipo == DOUBLE)
+    {
+        long *ai = x.dados;
+        double a = *ai;
+        double *b = y.dados;
+        
+        if (*b < a)
+            push_long(s, 1);
+        else
+            push_long(s, 0);        
+    }
+    else if (x.tipo == DOUBLE && y.tipo == LONG)
+    {
+        double *a = x.dados;
+        long *bi = y.dados;
+        double b = *bi;
+        
+        if (b < *a)
+            push_long(s, 1);
+        else
+            push_long(s, 0);
+    }
+    else if (x.tipo == DOUBLE && y.tipo == DOUBLE)
+    {
+        double *a = x.dados;
+        double *b = y.dados;
+        
+        if (*b < *a)
+            push_long(s, 1);
+        else
+            push_long(s, 0);
+    }
 
     free(x.dados);
     free(y.dados);

--- a/src/stack.c
+++ b/src/stack.c
@@ -50,12 +50,12 @@ void initialize_var(DADOS *var)
     var[18].tipo = CHAR;
     var[18].dados = s;
 
-    for (i=19; i<26; i++)
+    for (i=23; i<26; i++)               // *r toma valor 0, 1 ou 2 para X, Y ou Z (respetivamente).
     {
-        long *r = malloc(sizeof(long));
-        *r = i - 18;                    // *r toma o valor 0, 1 ou 2 para X, Y ou Z (respetivamente).
+        long *x = malloc(sizeof(long));
+        *x = i - 23;
         var[i].tipo = LONG;
-        var[i].dados = r;
+        var[i].dados = x;
     }
 }
 


### PR DESCRIPTION
- __Nota__: É necessário converter algumas das funções em expLogic.c de modo a suportarem operações com doubles, como foi feito em equal() e smaller().
